### PR TITLE
feature: 新增支持env,HTTPS的配置

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -14,5 +15,8 @@ class AppServiceProvider extends ServiceProvider
     
     public function boot()
     {
-            }
+        if (env('HTTPS',false)) {
+            URL::forceScheme('https');
+        }
+    }
 }

--- a/env.example
+++ b/env.example
@@ -2,6 +2,8 @@ APP_ENV=product
 APP_DEBUG=true
 APP_KEY=4LmYVxyQ0twIjPtNguwEgxDN68oEhBYH
 
+HTTPS=false
+
 DB_HOST=localhost
 DB_PORT=3306
 DB_DATABASE=database


### PR DESCRIPTION
原因是：
当域名添加证书时候，后台有些功能，例如内容管理-新增，会出现问题如下：
```
Mixed Content: The page at 'https://xxx.com/admin/cms/content/1' was loaded over HTTPS, but requested an insecure frame 'http://xxx.com/admin/cms/content/edit/1'. This request has been blocked; the content must be served over HTTPS.
```
通过配置，可强制生成的url都为https，解决该问题